### PR TITLE
Add ability to transpose text object coordinates.

### DIFF
--- a/lib/pdf-reader-turtletext.rb
+++ b/lib/pdf-reader-turtletext.rb
@@ -1,6 +1,7 @@
 require 'pdf-reader'
 require 'pdf/reader/patch/object_hash'
 require 'pdf/reader/positional_text_receiver'
+require 'pdf/reader/transposed_positional_text_receiver'
 
 require 'pdf/reader/turtletext'
 require 'pdf/reader/turtletext/version'

--- a/lib/pdf/reader/transposed_positional_text_receiver.rb
+++ b/lib/pdf/reader/transposed_positional_text_receiver.rb
@@ -1,0 +1,31 @@
+# Receiver to access positional (x,y) text content from a PDF
+#
+# Typical usage:
+#
+#   reader = PDF::Reader.new(filename)
+#   receiver = PDF::Reader::TransposedPositionalTextReceiver.new
+#   reader.page(page).walk(receiver)
+#   receiver.content
+#
+class PDF::Reader::TransposedPositionalTextReceiver < PDF::Reader::PositionalTextReceiver
+
+  # record text that is drawn on the page
+  def show_text(string) # Tj
+    raise PDF::Reader::MalformedPDFError, "current font is invalid" if @state.current_font.nil?
+    newx, newy = @state.trm_transform(0,0)
+    @content[newx] ||= {}
+    @content[newx][newy] ||= ''
+    @content[newx][newy] << @state.current_font.to_utf8(string)
+  end
+
+  # override PageTextReceiver content accessor .
+  # Returns a hash of positional text:
+  #   {
+  #     x_coord=>{y_coord=>text, y_coord=>text },
+  #     x_coord=>{y_coord=>text, y_coord=>text }
+  #   }
+  def content
+    super
+  end
+
+end


### PR DESCRIPTION
While using this gem, I have a use case where my PDFs are in landscape orientation and the ability to transpose the coordinates greatly improves the organization of the output when calling `content`.

I wanted to run this by you and get your opinion on if it was worth adding. If so, please advise on tests you would like to see.